### PR TITLE
Error message update

### DIFF
--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -2,7 +2,7 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can’t be updated when it’s running from a read-only volume like a disk image or an optical drive. Move %1$@ to Applications folder using Finder, relaunch it from there, and try again.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 


### PR DESCRIPTION
This adopts the new error message from the Sparkle project which is clearer in cases of translocation (i.e., running from `~/Downloads`).
